### PR TITLE
Added high-level diagrams

### DIFF
--- a/.codeboarding/Core Initialization & Model Management.md
+++ b/.codeboarding/Core Initialization & Model Management.md
@@ -1,0 +1,70 @@
+```mermaid
+graph LR
+    Data_Loader["Data Loader"]
+    Molecular_Embedder["Molecular Embedder"]
+    Demo_Model["Demo Model"]
+    ML_Feature_Processor["ML Feature Processor"]
+    Hyperparameter_Search["Hyperparameter Search"]
+    Demo_Model -- "loads data from" --> Data_Loader
+    Demo_Model -- "uses" --> Molecular_Embedder
+    Hyperparameter_Search -- "preprocesses features using" --> ML_Feature_Processor
+    Hyperparameter_Search -- "optimizes" --> Demo_Model
+```
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+## Component Details
+
+This component overview details the foundational elements of the system, focusing on data preparation, model initialization, and hyperparameter optimization. The primary flow involves loading a lipophilicity dataset, converting molecular structures into numerical fingerprints, and then either loading a pre-trained SVR model or training a new one with optimized hyperparameters. This ensures that the system has access to properly formatted data and a well-configured predictive model for subsequent tasks.
+
+### Data Loader
+Responsible for loading the lipophilicity dataset from a specified source, handling download if necessary.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/example.py#L21-L28" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.example:read_data` (21:28)</a>
+
+
+### Molecular Embedder
+Converts SMILES strings into numerical molecular fingerprints using RDKit, specifically Morgan fingerprints.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/example.py#L31-L45" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.example.RDKitEmbedder` (31:45)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/example.py#L36-L45" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.example.RDKitEmbedder.encode` (36:45)</a>
+
+
+### Demo Model
+Encapsulates the demo machine learning model (SVR) and its prediction capabilities, including its initialization and training process.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/example.py#L48-L53" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.example.Model` (48:53)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/example.py#L49-L50" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.example.Model:__init__` (49:50)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/example.py#L52-L53" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.example.Model:predict` (52:53)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/example.py#L56-L71" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.example:get_demo_model` (56:71)</a>
+
+
+### ML Feature Processor
+Provides utilities for preprocessing features for machine learning models, handling different data types.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/ml_helper.py#L13-L34" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.ml_helper.get_features` (13:34)</a>
+
+
+### Hyperparameter Search
+Manages the hyperparameter optimization process for machine learning models using techniques like HalvingRandomSearchCV and evaluates model performance.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/ml_helper.py#L100-L181" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.ml_helper:hp_search_helper` (100:181)</a>
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Molecular Attribution Methods.md
+++ b/.codeboarding/Molecular Attribution Methods.md
@@ -1,0 +1,78 @@
+```mermaid
+graph LR
+    SMILES_Attributor["SMILES Attributor"]
+    Atom_Attributor["Atom Attributor"]
+    Path_Attributor["Path Attributor"]
+    SHAP_Morgan_Attributor["SHAP Morgan Attributor"]
+    ML_Helper["ML Helper"]
+    SMILES_Attributor -- "depends on" --> ML_Helper
+    Atom_Attributor -- "depends on" --> ML_Helper
+    SHAP_Morgan_Attributor -- "depends on" --> ML_Helper
+```
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+## Component Details
+
+This graph represents the 'Molecular Attribution Methods' component, which provides various techniques for attributing model predictions back to molecular substructures or atoms. The main flow involves different attribution strategies: SMILES-based, atom-based, path-based, and SHAP with Morgan fingerprints. These strategies generate mutations or calculate scores to explain model predictions, often relying on a shared ML Helper component for feature extraction and model utility functions.
+
+### SMILES Attributor
+This component attributes importance to parts of SMILES strings by generating various mutations (substitutions) of the original SMILES. It then uses a predictor model to evaluate the impact of these mutations on the prediction, thereby quantifying the attribution of each part of the SMILES string. It also includes a utility to silence RDKit output during SMILES validation.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/smiles_attributor.py#L138-L156" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.smiles_attributor:attribute_smiles` (138:156)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/smiles_attributor.py#L159-L247" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.smiles_attributor:generate_mutations` (159:247)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/smiles_attributor.py#L130-L136" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.smiles_attributor:predictor_smiles` (130:136)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/smiles_attributor.py#L88-L123" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.smiles_attributor._Silencer` (88:123)</a>
+
+
+### Atom Attributor
+This component focuses on attributing importance to individual atoms within a molecule. It generates mutations by systematically replacing atoms with other organic atom symbols and then uses a predictor model to assess the change in prediction. This allows for the quantification of each atom's contribution to the overall prediction. It also uses a silencer for RDKit output.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/atom_attributor.py#L101-L120" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.atom_attributor:attribute_atoms` (101:120)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/atom_attributor.py#L55-L89" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.atom_attributor:mutate_atoms` (55:89)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/atom_attributor.py#L92-L98" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.atom_attributor:predictor_on_smiles` (92:98)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/atom_attributor.py#L18-L53" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.atom_attributor._Silencer` (18:53)</a>
+
+
+### Path Attributor
+This component is responsible for identifying all possible paths between atoms in a molecular graph and generating mutated molecules by removing atoms along these paths. It uses a Depth-First Search (DFS) algorithm to find paths and then applies atom removal to create mutations for attribution analysis.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/path_attributor.py#L4-L20" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.path_attributor:find_all_paths` (4:20)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/path_attributor.py#L38-L59" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.path_attributor:mutations_along_paths` (38:59)</a>
+
+
+### SHAP Morgan Attributor
+This component calculates SHAP (SHapley Additive exPlanations) attributions for molecular predictions, specifically leveraging Morgan fingerprints. It determines the contribution of each atom to the model's output by analyzing the coefficients derived from SHAP values and distributing them across the atoms based on their presence in fingerprint bits.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/SHAP_MORGAN_attributor.py#L45-L63" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.SHAP_MORGAN_attributor:get_SHAP_Morgan_attributions` (45:63)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/SHAP_MORGAN_attributor.py#L34-L43" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.SHAP_MORGAN_attributor:weights_morgan` (34:43)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/SHAP_MORGAN_attributor.py#L8-L32" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.SHAP_MORGAN_attributor:calculate_atom_weights` (8:32)</a>
+
+
+### ML Helper
+This component provides foundational machine learning utility functions. It handles feature extraction from molecular data, including the generation of various types of fingerprints (Morgan, MACCS, RDKit), and offers a helper function for hyperparameter searching for machine learning models.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/ml_helper.py#L13-L34" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.ml_helper.get_features` (13:34)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/ml_helper.py#L36-L55" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.ml_helper.get_morgan_fingerprint` (36:55)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/ml_helper.py#L57-L76" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.ml_helper.get_MACCS_fingerprint` (57:76)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/ml_helper.py#L79-L98" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.ml_helper.get_RDK_fingerprint` (79:98)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/ml_helper.py#L100-L181" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.ml_helper.hp_search_helper` (100:181)</a>
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Molecular Feature Engineering.md
+++ b/.codeboarding/Molecular Feature Engineering.md
@@ -1,0 +1,83 @@
+```mermaid
+graph LR
+    Data_Handling_Component["Data Handling Component"]
+    Molecular_Feature_Engineering_Component["Molecular Feature Engineering Component"]
+    Model_Training_and_Prediction_Component["Model Training and Prediction Component"]
+    Atom_Attribution_Component["Atom Attribution Component"]
+    SHAP_Morgan_Attributor_Component["SHAP Morgan Attributor Component"]
+    Model_Training_and_Prediction_Component -- "uses" --> Data_Handling_Component
+    Model_Training_and_Prediction_Component -- "uses" --> Molecular_Feature_Engineering_Component
+    Atom_Attribution_Component -- "uses" --> Data_Handling_Component
+    Atom_Attribution_Component -- "uses" --> Model_Training_and_Prediction_Component
+    Atom_Attribution_Component -- "uses" --> Molecular_Feature_Engineering_Component
+    SHAP_Morgan_Attributor_Component -- "uses" --> Data_Handling_Component
+    SHAP_Morgan_Attributor_Component -- "uses" --> Model_Training_and_Prediction_Component
+    SHAP_Morgan_Attributor_Component -- "uses" --> Molecular_Feature_Engineering_Component
+```
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+## Component Details
+
+This graph illustrates the key components of a molecular machine learning system, focusing on data handling, molecular feature engineering, model training and prediction, and explainability through atom attribution and SHAP analysis for Morgan fingerprints. It highlights how these components interact to process molecular data, build predictive models, and provide insights into model decisions.
+
+### Data Handling Component
+This component is responsible for reading and preprocessing data, including downloading datasets, loading CSV files into pandas DataFrames, and extracting features from data based on specified columns, handling both numpy arrays and single-column values.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/example.py#L21-L28" target="_blank" rel="noopener noreferrer">`xai_selfies.example:read_data` (21:28)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/ml_helper.py#L13-L34" target="_blank" rel="noopener noreferrer">`xai_selfies.ml_helper:get_features` (13:34)</a>
+
+
+### Molecular Feature Engineering Component
+This component handles the transformation of molecular structures (SMILES) into numerical features suitable for machine learning models. It provides utilities for generating various types of molecular fingerprints, which are crucial for model input.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/example.py#L31-L45" target="_blank" rel="noopener noreferrer">`xai_selfies.example.RDKitEmbedder` (31:45)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/example.py#L36-L45" target="_blank" rel="noopener noreferrer">`xai_selfies.example.RDKitEmbedder:encode` (36:45)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/ml_helper.py#L36-L55" target="_blank" rel="noopener noreferrer">`xai_selfies.ml_helper:get_morgan_fingerprint` (36:55)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/ml_helper.py#L57-L76" target="_blank" rel="noopener noreferrer">`xai_selfies.ml_helper:get_MACCS_fingerprint` (57:76)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/ml_helper.py#L79-L98" target="_blank" rel="noopener noreferrer">`xai_selfies.ml_helper:get_RDK_fingerprint` (79:98)</a>
+
+
+### Model Training and Prediction Component
+This component encapsulates the core machine learning model functionalities, including training a demo model (SVR), making predictions, and handling model persistence. It also provides a helper function for hyperparameter search and cross-validation.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/example.py#L48-L53" target="_blank" rel="noopener noreferrer">`xai_selfies.example.Model` (48:53)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/example.py#L52-L53" target="_blank" rel="noopener noreferrer">`xai_selfies.example.Model:predict` (52:53)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/example.py#L56-L71" target="_blank" rel="noopener noreferrer">`xai_selfies.example:get_demo_model` (56:71)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/ml_helper.py#L100-L181" target="_blank" rel="noopener noreferrer">`xai_selfies.ml_helper:hp_search_helper` (100:181)</a>
+
+
+### Atom Attribution Component
+This component is responsible for attributing importance scores to individual atoms within a molecule based on a trained predictor. It involves mutating atoms and using the predictor to evaluate the impact of these mutations, providing insights into atomic contributions to model predictions.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/atom_attributor.py#L55-L89" target="_blank" rel="noopener noreferrer">`xai_selfies.atom_attributor:mutate_atoms` (55:89)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/atom_attributor.py#L92-L98" target="_blank" rel="noopener noreferrer">`xai_selfies.atom_attributor:predictor_on_smiles` (92:98)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/atom_attributor.py#L101-L120" target="_blank" rel="noopener noreferrer">`xai_selfies.atom_attributor:attribute_atoms` (101:120)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/atom_attributor.py#L18-L53" target="_blank" rel="noopener noreferrer">`xai_selfies.atom_attributor._Silencer` (18:53)</a>
+
+
+### SHAP Morgan Attributor Component
+This component specifically focuses on generating SHAP (SHapley Additive exPlanations) attributions for Morgan fingerprints. It leverages feature preparation and calculates attribution weights to provide explainability for models using Morgan fingerprints.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/SHAP_MORGAN_attributor.py#L8-L32" target="_blank" rel="noopener noreferrer">`xai_selfies.SHAP_MORGAN_attributor:calculate_atom_weights` (8:32)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/SHAP_MORGAN_attributor.py#L34-L43" target="_blank" rel="noopener noreferrer">`xai_selfies.SHAP_MORGAN_attributor:weights_morgan` (34:43)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/SHAP_MORGAN_attributor.py#L45-L63" target="_blank" rel="noopener noreferrer">`xai_selfies.SHAP_MORGAN_attributor:get_SHAP_Morgan_attributions` (45:63)</a>
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/SELFIES Attribution Orchestration.md
+++ b/.codeboarding/SELFIES Attribution Orchestration.md
@@ -1,0 +1,59 @@
+```mermaid
+graph LR
+    XAI_Attribution_Orchestrator["XAI Attribution Orchestrator"]
+    Molecular_Mutation_Generator["Molecular Mutation Generator"]
+    Molecular_Prediction_Interface["Molecular Prediction Interface"]
+    SMILES_SELFIES_Conversion_Scoring["SMILES/SELFIES Conversion & Scoring"]
+    XAI_Attribution_Orchestrator -- "initiates" --> Molecular_Mutation_Generator
+    XAI_Attribution_Orchestrator -- "requests predictions from" --> Molecular_Prediction_Interface
+    XAI_Attribution_Orchestrator -- "utilizes transformations from" --> SMILES_SELFIES_Conversion_Scoring
+```
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+## Component Details
+
+This graph represents the SELFIES Attribution Orchestration subsystem, which is responsible for generating SELFIES mutations, obtaining predictions, translating scores, and ordering results to provide atom-level attributions for molecules. The main flow starts with the XAI Attribution Orchestrator, which coordinates the mutation generation, prediction, and score conversion processes to produce a final attribution dataframe.
+
+### XAI Attribution Orchestrator
+This is the central control component that orchestrates the entire SELFIES-based attribution workflow. It manages the generation of SELFIES mutations, obtains predictions for original and mutated molecules, translates SELFIES-level scores to SMILES atom-level attributions, and handles canonical ordering of results, integrating various sub-processes to deliver the final attribution dataframe.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/main.py#L207-L267" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.main:get_attributions_df` (207:267)</a>
+
+
+### Molecular Mutation Generator
+This component is responsible for generating various mutated forms of a given molecule in SELFIES format and filtering these mutations based on a specified similarity threshold to the original molecule.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/main.py#L147-L184" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.main:get_all_mutations` (147:184)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/main.py#L44-L81" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.main:get_mutated_selfies` (44:81)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/main.py#L84-L103" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.main:filter_candidates` (84:103)</a>
+
+
+### Molecular Prediction Interface
+This component interfaces with a machine learning model and an embedder to obtain predictions for both original and mutated molecular structures.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/main.py#L187-L204" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.main:get_predictions_for_mutants_and_original` (187:204)</a>
+
+
+### SMILES/SELFIES Conversion & Scoring
+This component handles the parsing, conversion, and reordering of chemical representations between SMILES and SELFIES formats, and manages the attribution scores associated with these transformations.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/main.py#L15-L26" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.main:smiles_parser` (15:26)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/main.py#L106-L144" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.main:score_from_selfies_to_smiles` (106:144)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/main.py#L29-L41" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.main:get_correct_order` (29:41)</a>
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/on_boarding.md
+++ b/.codeboarding/on_boarding.md
@@ -1,0 +1,89 @@
+```mermaid
+graph LR
+    Core_Initialization_Model_Management["Core Initialization & Model Management"]
+    Molecular_Feature_Engineering["Molecular Feature Engineering"]
+    Molecular_Attribution_Methods["Molecular Attribution Methods"]
+    SELFIES_Attribution_Orchestration["SELFIES Attribution Orchestration"]
+    Core_Initialization_Model_Management -- "Provides initialized model and embedder" --> SELFIES_Attribution_Orchestration
+    Molecular_Feature_Engineering -- "Generates features for model training/embedding" --> Core_Initialization_Model_Management
+    Molecular_Feature_Engineering -- "Provides molecular features for attribution" --> Molecular_Attribution_Methods
+    Core_Initialization_Model_Management -- "Provides trained model for predictions" --> Molecular_Attribution_Methods
+    Molecular_Attribution_Methods -- "Generates molecular mutations and preliminary scores" --> SELFIES_Attribution_Orchestration
+    SELFIES_Attribution_Orchestration -- "Requests feature encoding for predictions" --> Molecular_Feature_Engineering
+    click Core_Initialization_Model_Management href "https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/mlr-xai-selfies/Core Initialization & Model Management.md" "Details"
+    click Molecular_Feature_Engineering href "https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/mlr-xai-selfies/Molecular Feature Engineering.md" "Details"
+    click Molecular_Attribution_Methods href "https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/mlr-xai-selfies/Molecular Attribution Methods.md" "Details"
+    click SELFIES_Attribution_Orchestration href "https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/mlr-xai-selfies/SELFIES Attribution Orchestration.md" "Details"
+```
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+## Component Details
+
+This graph represents the architecture of the `mlr-xai-selfies` project, which focuses on explainable AI for molecular machine learning, particularly using SELFIES for attribution. The main flow involves initializing models and data, generating molecular features, applying various attribution methods to understand model predictions, and orchestrating the SELFIES-based attribution workflow to provide atom-level insights into molecular properties.
+
+### Core Initialization & Model Management
+This component is responsible for setting up the foundational elements of the system, including reading input datasets, initializing or loading machine learning models, and optimizing their hyperparameters. It ensures that the necessary data and predictive models are prepared and optimally configured for subsequent use.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/example.py#L21-L28" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.example:read_data` (21:28)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/example.py#L31-L45" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.example.RDKitEmbedder` (31:45)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/example.py#L48-L53" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.example.Model` (48:53)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/example.py#L56-L71" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.example:get_demo_model` (56:71)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/ml_helper.py#L100-L181" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.ml_helper:hp_search_helper` (100:181)</a>
+
+
+### Molecular Feature Engineering
+This component handles the transformation of molecular structures (SMILES) into numerical features suitable for machine learning models. It provides utilities for generating various types of molecular fingerprints, which are crucial for model input.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/ml_helper.py#L13-L34" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.ml_helper:get_features` (13:34)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/ml_helper.py#L36-L55" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.ml_helper:get_morgan_fingerprint` (36:55)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/ml_helper.py#L57-L76" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.ml_helper:get_MACCS_fingerprint` (57:76)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/ml_helper.py#L79-L98" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.ml_helper:get_RDK_fingerprint` (79:98)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/example.py#L36-L45" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.example.RDKitEmbedder:encode` (36:45)</a>
+
+
+### Molecular Attribution Methods
+This component encompasses various techniques for attributing model predictions back to molecular substructures or atoms. It includes methods for generating mutations based on SMILES characters, individual atoms, or molecular paths, and calculating attribution scores using these mutations or SHAP.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/smiles_attributor.py#L138-L156" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.smiles_attributor:attribute_smiles` (138:156)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/smiles_attributor.py#L159-L247" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.smiles_attributor:generate_mutations` (159:247)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/smiles_attributor.py#L130-L136" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.smiles_attributor:predictor_smiles` (130:136)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/smiles_attributor.py#L88-L123" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.smiles_attributor._Silencer` (88:123)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/atom_attributor.py#L101-L120" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.atom_attributor:attribute_atoms` (101:120)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/atom_attributor.py#L55-L89" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.atom_attributor:mutate_atoms` (55:89)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/atom_attributor.py#L92-L98" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.atom_attributor:predictor_on_smiles` (92:98)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/atom_attributor.py#L18-L53" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.atom_attributor._Silencer` (18:53)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/path_attributor.py#L4-L20" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.path_attributor:find_all_paths` (4:20)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/path_attributor.py#L38-L59" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.path_attributor:mutations_along_paths` (38:59)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/SHAP_MORGAN_attributor.py#L45-L63" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.SHAP_MORGAN_attributor:get_SHAP_Morgan_attributions` (45:63)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/SHAP_MORGAN_attributor.py#L34-L43" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.SHAP_MORGAN_attributor:weights_morgan` (34:43)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/SHAP_MORGAN_attributor.py#L8-L32" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.SHAP_MORGAN_attributor:calculate_atom_weights` (8:32)</a>
+
+
+### SELFIES Attribution Orchestration
+This is the central control component that orchestrates the entire SELFIES-based attribution workflow. It manages the generation of SELFIES mutations, obtains predictions for original and mutated molecules, translates SELFIES-level scores to SMILES atom-level attributions, and handles canonical ordering of results, integrating various sub-processes to deliver the final attribution dataframe.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/main.py#L207-L267" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.main:get_attributions_df` (207:267)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/main.py#L147-L184" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.main:get_all_mutations` (147:184)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/main.py#L44-L81" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.main:get_mutated_selfies` (44:81)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/main.py#L84-L103" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.main:filter_candidates` (84:103)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/main.py#L106-L144" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.main:score_from_selfies_to_smiles` (106:144)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/main.py#L15-L26" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.main:smiles_parser` (15:26)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/main.py#L29-L41" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.main:get_correct_order` (29:41)</a>
+- <a href="https://github.com/Bayer-Group/mlr-xai-selfies/blob/master/xai_selfies/main.py#L187-L204" target="_blank" rel="noopener noreferrer">`mlr-xai-selfies.xai_selfies.main:get_predictions_for_mutants_and_original` (187:204)</a>
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)


### PR DESCRIPTION
This PR contains high-level diagrams for the mlr-xai-selfies' codebase. You can see how they render in Github here:
https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/mlr-xai-selfies/on_boarding.md

The idea of these diagrams are to help people get up-to-speed with the codebase. I know that a lot of scientists interact with these codebases and I suppose they can make use of such diagrams and grasp the idea much faster than reading the code itself. I would love to hear what do you think about diagram first documentation for on-boarding and if it fits in your existing on-boarding processes.

We are also developing a github action which can generate the documentation for every commit in main. It will be available soon so let me know if that sounds interesting!

Any feedback is more than welcome!

Full disclosure: we're trying to turn this into a startup, but we're still in a very early stage and figuring out what will actually be useful for people.